### PR TITLE
[fix] - Darwin* uses glibtoolize instead of libtoolize.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -56,7 +56,10 @@ if [ -z "$skip_submodules" ] || [ "$skip_modules" = 0 ]; then
 fi
 
 # bootstrap syslog-ng itself
-libtoolize --force --copy
+case `uname` in
+  Darwin*) glibtoolize --copy  ;;
+  *) libtoolize --force --copy ;;
+esac
 aclocal -I m4 --install
 sed -i -e 's/PKG_PROG_PKG_CONFIG(\[0\.16\])/PKG_PROG_PKG_CONFIG([0.14])/g' aclocal.m4
 


### PR DESCRIPTION
This fix is for Darwnin based OSX. Will fix autogen.sh
```
autoreconf: Leaving directory `.'
autogen.sh: line 59: libtoolize: command not found
aclocal: installing 'm4/ax_prefix_config_h.m4' from '/usr/local/share/aclocal/ax_prefix_config_h.m4'
configure.ac:307: error: required file './ltmain.sh' not found
```